### PR TITLE
Fixed crash caused by using vmapped memory for DMA

### DIFF
--- a/dmx_usb.c
+++ b/dmx_usb.c
@@ -20,7 +20,7 @@
 #include <linux/module.h>
 #include <linux/spinlock.h>
 #include <linux/completion.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/usb.h>
 #include <linux/version.h>
 

--- a/dmx_usb.c
+++ b/dmx_usb.c
@@ -408,7 +408,7 @@ exit_not_opened:
 	return retval;
 }
 
-#if 0 
+#if 0
 
 Read is not yet supported
 
@@ -460,7 +460,8 @@ static __u16 dmx_usb_get_status(struct dmx_usb_device* dev)
 {
 	int *count = NULL;
 	__u16 *buf = NULL;
-	int retval;
+	__u16 status;
+	int bulk_retval;
 
 	count = kmalloc(sizeof (*count), GFP_KERNEL);
 	if (count == NULL)
@@ -470,16 +471,17 @@ static __u16 dmx_usb_get_status(struct dmx_usb_device* dev)
 	if (buf == NULL)
 		goto error;
 
-	retval = usb_bulk_msg (dev->udev,
+	bulk_retval = usb_bulk_msg (dev->udev,
 				usb_rcvbulkpipe (dev->udev, dev->bulk_in_endpointAddr),
-				buf, 2, count, HZ*10);
+				buf, sizeof(*buf), count, HZ*10);
 
-	if (retval)
+	if (bulk_retval)
 		goto error;
 
+	status = *buf;
 	kfree(buf);
 	kfree(count);
-	return *buf;
+	return status;
 
 error:
 	kfree(buf);
@@ -580,6 +582,7 @@ static ssize_t dmx_usb_write (struct file *file, const char *buffer, size_t coun
 	} else {
 		retval = bytes_written;
 	}
+
 
 exit:
 	/* unlock the device */


### PR DESCRIPTION
As of Linux 4.9, the kernel virtual memory maps its stacks. Virtual
memory addresses cannot be used for direct memory access (DMA). Many
usb_* functions use memory referenced by its arguments for DMA. For
example, the call;

    usb_bulk_msg(dev->udev,
                 usb_rcvbulkpipe(dev->udev, dev->bulk_in_endpointAddr),
                 &buf, 2, &count, HZ*10);

in `dmx_usb_status()` uses the memory referenced by `buf` and `count`
for DMA. These were automatic variables allocated on the stack, which is
now vmapped. The call failed and `usbcore` reported:

    [   46.724753] ------------[ cut here ]------------
    [   46.724761] WARNING: CPU: 3 PID: 1169 at drivers/usb/core/hcd.c:1584 usb_hcd_map_urb_for_dma+0x42a/0x550 [usbcore]
    [   46.724762] transfer buffer not dma capable
    [   46.724762] Modules linked in: ctr ccm sctp_diag sctp libcrc32c crc32c_generic dccp_diag dccp tcp_diag udp_diag inet_diag unix_diag fuse snd_hda_codec_hdmi joydev mousedev arc4 intel_rapl x86_pkg_temp_thermal intel_powerclamp iTCO_wdt coretemp iTCO_vendor_support kvm_intel kvm iwlmvm irqbypass mxm_wmi crct10dif_pclmul crc32_pclmul crc32c_intel ghash_clmulni_intel mac80211 i915 btusb btrtl snd_hda_codec_via btbcm snd_hda_codec_generic btintel aesni_intel iwlwifi drm_kms_helper evdev input_leds bluetooth aes_x86_64 lrw snd_hda_intel gf128mul glue_helper dmx_usb(O) cdc_acm cfg80211 ablk_helper snd_hda_codec cryptd drm snd_hda_core led_class intel_cstate snd_hwdep psmouse intel_rapl_perf mac_hid i2c_i801 intel_gtt snd_pcm i2c_smbus rfkill syscopyarea sysfillrect snd_timer sysimgblt rtsx_pci_ms snd fb_sys_fops
    [   46.724797]  r8169 i2c_algo_bit memstick soundcore mei_me mii ie31200_edac mei edac_core shpchp lpc_ich thermal wmi tpm_infineon fjes video battery tpm_tis button ac tpm_tis_core tpm sch_fq_codel vboxnetflt(O) vboxnetadp(O) pci_stub vboxpci(O) vboxdrv(O) ip_tables x_tables ext4 crc16 jbd2 fscrypto mbcache sr_mod cdrom sd_mod rtsx_pci_sdmmc mmc_core serio_raw atkbd libps2 ahci libahci xhci_pci ehci_pci libata xhci_hcd ehci_hcd usbcore scsi_mod rtsx_pci usb_common i8042 serio
    [   46.724822] CPU: 3 PID: 1169 Comm:  Tainted: G           O    4.9.7-1-ARCH #1
    [   46.724822] Hardware name: Notebook                         W35xSTQ_370ST             /W35xSTQ_370ST             , BIOS 4.6.5 01/16/2014
    [   46.724823]  ffffc90003f6bb00 ffffffff813055b0 ffffc90003f6bb50 0000000000000000
    [   46.724825]  ffffc90003f6bb40 ffffffff8107eb0b 0000063000000000 ffff8803fc405c00
    [   46.724827]  0000000000000000 ffff88041bed8000 0000000000000002 ffff88041d1b0000
    [   46.724829] Call Trace:
    [   46.724833]  [<ffffffff813055b0>] dump_stack+0x63/0x83
    [   46.724835]  [<ffffffff8107eb0b>] __warn+0xcb/0xf0
    [   46.724836]  [<ffffffff8107eb8f>] warn_slowpath_fmt+0x5f/0x80
    [   46.724841]  [<ffffffffa00c8cc9>] ? usb_alloc_urb+0x19/0x50 [usbcore]
    [   46.724843]  [<ffffffffa00c689a>] usb_hcd_map_urb_for_dma+0x42a/0x550 [usbcore]
    [   46.724846]  [<ffffffffa00c78c5>] usb_hcd_submit_urb+0x335/0xb30 [usbcore]
    [   46.724848]  [<ffffffffa00d05a5>] ? usb_open+0x95/0xa0 [usbcore]
    [   46.724850]  [<ffffffff81216ee0>] ? chrdev_open+0xb0/0x1e0
    [   46.724853]  [<ffffffffa00c9274>] usb_submit_urb+0x2f4/0x560 [usbcore]
    [   46.724854]  [<ffffffff8121c6f5>] ? terminate_walk+0x95/0x100
    [   46.724857]  [<ffffffffa00c9a1e>] usb_start_wait_urb+0x6e/0x170 [usbcore]
    [   46.724859]  [<ffffffffa00c9f6d>] usb_bulk_msg+0xbd/0x160 [usbcore]
    [   46.724861]  [<ffffffffa062161f>] 0xffffffffa062161f
    [   46.724863]  [<ffffffff81211397>] __vfs_write+0x37/0x140
    [   46.724864]  [<ffffffff81212156>] vfs_write+0xb6/0x1a0
    [   46.724865]  [<ffffffff812135e5>] SyS_write+0x55/0xc0
    [   46.724868]  [<ffffffff8160a737>] entry_SYSCALL_64_fastpath+0x1a/0xa9
    [   46.724869] ---[ end trace d4fcf8b709a90def ]---

This is fixed by `kalloc`-ing memory to be used for DMA.

Also, fixed;

    xhci_hcd 0000:00:14.0: dma_pool_free buffer-2048, ffff8801c89cc080/1c89cc080 (bad dma)

which occurs when unplugging the device, by storing the
`usb_alloc_coherent` size in a new `dmx_usb_device` field,
`bulk_out_alloc_size`, and passing that to `usb_free_coherent`.

I'm not an expert (this is my first time out of user-space), so I can't
claim the fix is good. Just that the DMX lights started flashing again.