### PR TITLE
update uaccess.h path

### DIFF
--- a/dmx_usb.c
+++ b/dmx_usb.c
@@ -20,7 +20,7 @@
 #include <linux/module.h>
 #include <linux/spinlock.h>
 #include <linux/completion.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/usb.h>
 #include <linux/version.h>
 


### PR DESCRIPTION
fixed build error on dmx_usb.c for 4.15 kernel (likely others):

./arch/x86/include/asm/uaccess.h:32:9: error: dereferencing pointer to incomplete type ‘struct task_struct’
  current->thread.addr_limit = fs;

as suggested @ https://lkml.org/lkml/2017/9/30/189

in /dmx_usb_module/dmx_usb.c:23

#include <asm/uaccess.h>
replaced with
#include <linux/uaccess.h>

linux/uaccess.h file contains line: '#include <asm/uaccess.h>'